### PR TITLE
Upload Using Programmer fails

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -99,6 +99,12 @@ tools.dslite.config.path={path}
 tools.dslite.cmd.path={path}/DebugServer/bin/DSLite
 tools.dslite.upload.pattern={cmd.path} {upload.verbose} load -c "{config.path}/{build.variant}.ccxml" -f "{build.path}/{build.project_name}.elf"
 
+tools.dslite.program.params.verbose=
+tools.dslite.program.params.quiet=
+tools.dslite.program.params.noverify=
+tools.dslite.program.pattern={cmd.path} {program.verbose} load -c "{config.path}/{build.variant}.ccxml" -f "{build.path}/{build.project_name}.elf"
+
+
 # mspdebug
 tools.mspdebug.upload.params.verbose=
 tools.mspdebug.upload.params.quiet=
@@ -106,5 +112,8 @@ tools.mspdebug.path={runtime.tools.mspdebug.path}
 tools.mspdebug.cmd.path={path}/bin/mspdebug
 tools.mspdebug.upload.pattern={cmd.path} {upload.verbose} {upload.protocol} --force-reset "prog {build.path}/{build.project_name}.hex"
 
-
+tools.mspdebug.program.params.verbose=
+tools.mspdebug.program.params.quiet=
+tools.mspdebug.program.params.noverify=
+tools.mspdebug.program.pattern={cmd.path} {program.verbose} {protocol} --force-reset "prog {build.path}/{build.project_name}.hex"
 

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,5 +1,7 @@
-rf2500.name=rf2500
-rf2500.protocol=rf2500
+mspdebug.name=mspdebug
+mspdebug.protocol=rf2500
+mspdebug.program.tool=mspdebug
 
 dslite.name=dslite
 dslite.protocol=dslite
+dslite.program.tool=dslite


### PR DESCRIPTION
I tried using the Sketch/Upload Using Programmer menu item and it failed with this message:
```
...
Sketch uses 782 bytes (4%) of program storage space. Maximum is 16,384 bytes.
Global variables use 32 bytes (6%) of dynamic memory, leaving 480 bytes for local variables. Maximum is 512 bytes.
Error while uploading: missing 'program.tool' configuration parameter
```
OS: Linux Ubuntu 15.10
Using EnergiaNG build. ( I wasn't sure If I should file this under the IDE or the core )
