### PR TITLE
Issue 31 FRAM

### DIFF
--- a/variants/MSP-EXP430FR4133LP/pins_energia.h
+++ b/variants/MSP-EXP430FR4133LP/pins_energia.h
@@ -39,7 +39,7 @@
 // Attribute for placing R/W variables in FRAM
 // Example
 //      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
-#define FRAM __attribute__((section(".text")))
+#define PLACE_IN_FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P2.5 */

--- a/variants/MSP-EXP430FR4133LP/pins_energia.h
+++ b/variants/MSP-EXP430FR4133LP/pins_energia.h
@@ -36,6 +36,10 @@
 #define BV(x) (1 << (x))
 #endif
 
+// Attribute for placing R/W variables in FRAM
+// Example
+//      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
+#define FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P2.5 */

--- a/variants/MSP-EXP430FR5739LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5739LP/pins_energia.h
@@ -36,6 +36,11 @@
 #define BV(x) (1 << (x))
 #endif
 
+// Attribute for placing R/W variables in FRAM
+// Example
+//      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
+#define FRAM __attribute__((section(".text")))
+
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 20;  /* P1.3 */
 static const uint8_t SCK     = 6;   /* P2.2 */

--- a/variants/MSP-EXP430FR5739LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5739LP/pins_energia.h
@@ -39,7 +39,7 @@
 // Attribute for placing R/W variables in FRAM
 // Example
 //      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
-#define FRAM __attribute__((section(".text")))
+#define PLACE_IN_FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 20;  /* P1.3 */

--- a/variants/MSP-EXP430FR5969LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5969LP/pins_energia.h
@@ -39,7 +39,7 @@
 // Attribute for placing R/W variables in FRAM
 // Example
 //      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
-#define FRAM __attribute__((section(".text")))
+#define PLACE_IN_FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P3.4 */

--- a/variants/MSP-EXP430FR5969LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5969LP/pins_energia.h
@@ -36,6 +36,10 @@
 #define BV(x) (1 << (x))
 #endif
 
+// Attribute for placing R/W variables in FRAM
+// Example
+//      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
+#define FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P3.4 */

--- a/variants/MSP-EXP430FR5994LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5994LP/pins_energia.h
@@ -39,7 +39,7 @@
 // Attribute for placing R/W variables in FRAM
 // Example
 //      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
-#define FRAM __attribute__((section(".text")))
+#define PLACE_IN_FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS0     = 47;  /* P4.0 */

--- a/variants/MSP-EXP430FR5994LP/pins_energia.h
+++ b/variants/MSP-EXP430FR5994LP/pins_energia.h
@@ -36,6 +36,10 @@
 #define BV(x) (1 << (x))
 #endif
 
+// Attribute for placing R/W variables in FRAM
+// Example
+//      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
+#define FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS0     = 47;  /* P4.0 */

--- a/variants/MSP-EXP430FR6989LP/pins_energia.h
+++ b/variants/MSP-EXP430FR6989LP/pins_energia.h
@@ -39,7 +39,7 @@
 // Attribute for placing R/W variables in FRAM
 // Example
 //      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
-#define FRAM __attribute__((section(".text")))
+#define PLACE_IN_FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P2.0 */

--- a/variants/MSP-EXP430FR6989LP/pins_energia.h
+++ b/variants/MSP-EXP430FR6989LP/pins_energia.h
@@ -36,6 +36,10 @@
 #define BV(x) (1 << (x))
 #endif
 
+// Attribute for placing R/W variables in FRAM
+// Example
+//      uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
+#define FRAM __attribute__((section(".text")))
 
 #if defined(__MSP430_HAS_EUSCI_B0__)
 static const uint8_t SS      = 8;   /* P2.0 */


### PR DESCRIPTION
Added attribute for placing R/W variables in FRAM

* Example

```
uint8_t DisplayBuffer[LCD_MAXIMUM_Y][LCD_MAXIMUM_X] FRAM;
```