### PR TITLE
Add support for paths with whitespaces.

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -43,10 +43,10 @@ compiler.size.cmd=msp430-elf-size
 build.extra_flags={compiler.mlarge_flag} -mhwmult=auto
 
 # These can be overridden in platform.local.txt
-compiler.c.extra_flags=-I{runtime.tools.msp430-elf-gcc.path}/include -I{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include
-compiler.c.elf.extra_flags=-L{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include
+compiler.c.extra_flags="-I{runtime.tools.msp430-elf-gcc.path}/include" "-I{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include"
+compiler.c.elf.extra_flags="-L{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include"
 compiler.S.extra_flags=
-compiler.cpp.extra_flags=-I{runtime.tools.msp430-elf-gcc.path}/include -I{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include
+compiler.cpp.extra_flags="-I{runtime.tools.msp430-elf-gcc.path}/include" "-I{runtime.tools.msp430-elf-gcc.path}/msp430-gcc-support-files/include"
 compiler.ar.extra_flags=
 compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
@@ -105,7 +105,7 @@ tools.mspdebug.upload.params.verbose=
 tools.mspdebug.upload.params.quiet=
 tools.mspdebug.path={runtime.tools.mspdebug.path}
 tools.mspdebug.cmd.path={path}/bin/mspdebug
-tools.mspdebug.upload.pattern={cmd.path} {upload.verbose} {upload.protocol} --force-reset "prog {build.path}/{build.project_name}.hex"
+tools.mspdebug.upload.pattern={cmd.path} {upload.verbose} {upload.protocol} --force-reset "prog '{build.path}/{build.project_name}.hex'"
 
 
 

--- a/platform.txt.oldgcc
+++ b/platform.txt.oldgcc
@@ -42,10 +42,10 @@ compiler.size.cmd=msp430-size
 build.extra_flags=
 
 # These can be overridden in platform.local.txt
-compiler.c.extra_flags=-I{runtime.tools.msp430-gcc.path}/include
-compiler.c.elf.extra_flags=-L{runtime.tools.msp430-gcc.path}/include
+compiler.c.extra_flags="-I{runtime.tools.msp430-gcc.path}/include"
+compiler.c.elf.extra_flags="-L{runtime.tools.msp430-gcc.path}/include"
 compiler.S.extra_flags=
-compiler.cpp.extra_flags=-I{runtime.tools.msp430-gcc.path}/include 
+compiler.cpp.extra_flags="-I{runtime.tools.msp430-gcc.path}/include" 
 compiler.ar.extra_flags=
 compiler.objcopy.eep.extra_flags=
 compiler.elf2hex.extra_flags=
@@ -109,10 +109,10 @@ tools.mspdebug.upload.params.verbose=
 tools.mspdebug.upload.params.quiet=
 tools.mspdebug.path={runtime.tools.mspdebug.path}
 tools.mspdebug.cmd.path={path}/mspdebug
-tools.mspdebug.upload.pattern={cmd.path} {upload.verbose} {upload.protocol} --force-reset "prog {build.path}/{build.project_name}.hex"
+tools.mspdebug.upload.pattern={cmd.path} {upload.verbose} {upload.protocol} --force-reset "prog '{build.path}/{build.project_name}.hex'"
 
 tools.mspdebug.program.params.verbose=
 tools.mspdebug.program.params.quiet=
 tools.mspdebug.program.params.noverify=
-tools.mspdebug.program.pattern={cmd.path} {program.verbose} {protocol} --force-reset "prog {build.path}/{build.project_name}.hex"
+tools.mspdebug.program.pattern={cmd.path} {program.verbose} {protocol} --force-reset "prog '{build.path}/{build.project_name}.hex'"
 


### PR DESCRIPTION
Now that dlbeer/mspdebug#47 is merged we can finally support paths with whitespaces by tweaking the platform.txt file.
**NOTE: This requires the latest version (master) of mspdebug or a backport of the above pull request to work.**