### PR TITLE
MSP430FR2xx_4xx: set vlo_freq variable to REFO clock frequency.

### DIFF
--- a/cores/msp430/wiring.c
+++ b/cores/msp430/wiring.c
@@ -138,10 +138,10 @@ void enableXtal(void)
 	/* Test the fault flag */
 	}while (SFRIFG1 & OFIFG);
 
-	/* If starting the XTAL timed out then fall back to VLO */
+	/* If starting the XTAL timed out then fall back to REFO */
 	if(!timeout) {
-		/* ACLK = VLO = ~ 12 KHz */
-		vlo_freq = 8000;
+		/* ACLK = REFO = ~ 32 KHz */
+		vlo_freq = 32768;
 		/* Source ACLK from REFO */
 		CSCTL4 |= SELA__REFOCLK;
 	}


### PR DESCRIPTION
When external XTAL is not present then the ACLK falls back to the REFO clock instead of the VLO for the MSP430FR2xx_4xx family. This patch matches the vlo_freq variable to the REFO frequency.